### PR TITLE
docs: Update release process in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-package-release.md
+++ b/.github/ISSUE_TEMPLATE/create-package-release.md
@@ -11,7 +11,7 @@ Please do the following steps in order to release a new version of the package:
 
 - [ ] Create or clone a branch for the release and make sure the latest commits from `main` have been merged in
 - [ ] Pull all tags with `git pull --tags`
-- [ ] Run `pylint` and `velin` on the entire package
+- [ ] Run `pre-commit run --all-files`
 - [ ] Run the test suite, including all optional tests
 - [ ] Run the `prep_release` command installed by `erutils[dev]` from the command line to generate a stub release notes file for the new version. Edit with an English-language summary and commit the file in place.
 - [ ] Generate all the documentation and review for errors and placeholders


### PR DESCRIPTION
Replaced 'Run `pylint` and `velin` on the entire package' with 'Run `pre-commit run --all-files`' in the release process steps.